### PR TITLE
Directive for raw strings

### DIFF
--- a/src/main/scala/com/emarsys/jwt/akka/http/JwtAuthentication.scala
+++ b/src/main/scala/com/emarsys/jwt/akka/http/JwtAuthentication.scala
@@ -25,6 +25,10 @@ trait JwtAuthentication {
 
   def jwtAuthenticate[UserData](um: FromStringUnmarshaller[UserData]): Directive1[UserData] = for {
     jwtToken <- optionalHeaderValueByName("Authorization").map(stripBearerPrefix)
+    userData <- jwtAuthenticateToken(jwtToken, um)
+  } yield userData
+
+  def jwtAuthenticateToken[UserData](jwtToken: Option[String], um: FromStringUnmarshaller[UserData]): Directive1[UserData] = for {
     authorizedToken <- checkAuthorization(jwtToken)
     decodedToken <- decodeToken(authorizedToken)
     userData <- convertToUserData(decodedToken, um)


### PR DESCRIPTION
Added directive to handle when the jwt came as a `Segment` or param (from email activation link or reset password).

Also would be good if the inner as[] would get a rename so it would not collide with the Directives.as[].